### PR TITLE
Honor custom library paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ OBJS=util.o marshaller.o rbtree.o mapped_file.o em_dict.o em_list.o pyrsistence.
 BIN=pyrsistence.so
 
 PYTHON_INCLUDES=$(shell python2.7-config --includes)
-PYTHON_LIBS=$(shell python2.7-config --libs)
+PYTHON_LIBS=$(shell python2.7-config --ldflags)
 
 # D=-D DEBUG -ggdb
 D=

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ PYTHON_LIBS=$(shell python2.7-config --ldflags)
 
 # D=-D DEBUG -ggdb
 D=
-CFLAGS=-Wall -Wno-unused-result -Wno-strict-aliasing -O2 $(PYTHON_INCLUDES) \
+CFLAGS += -Wall -Wno-unused-result -Wno-strict-aliasing -O2 $(PYTHON_INCLUDES) \
 	-fPIC $(D)
-LDFLAGS=$(PYTHON_LIBS) -shared
+LDFLAGS += $(PYTHON_LIBS) -shared
 
 all: $(OBJS)
 	$(CC) $(OBJS) -o $(BIN) $(LDFLAGS)


### PR DESCRIPTION
Fixes compilation issue under macOS when not using
default python2.7-apple version.